### PR TITLE
force usage of Groovy 1.8.9 because of http://jira.codehaus.org/browse/G...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <blueprints.version>1.2</blueprints.version>
         <gremlin.version>1.5</gremlin.version>
         <jersey.server.version>1.6</jersey.server.version>
+        <groovy.version>1.8.9</groovy.version>
         <license-text.header>GPL-3-header.txt</license-text.header>
         <docs.url>http://docs.neo4j.org/chunked/${project.version}/gremlin-plugin.html</docs.url>
     </properties>
@@ -228,6 +229,16 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- force a newer version of groovy
+            artifact gremlin-groovy bundles groovy 1.8.4 which suffers from
+            http://jira.codehaus.org/browse/GROOVY-5187 -->
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>${groovy.version}</version>
+        </dependency>
+            
     </dependencies>
     <build>
         <resources>


### PR DESCRIPTION
Groovy 1.8.9 seems to have a significant bug fixed regarding memory consumption, http://jira.codehaus.org/browse/GROOVY-5187. This PR adds a explicit dependency to Groovy 1.8.9 overriding the transitive dependency to Groovy 1.8.4 from gremlin-groovy-1.5.
