### PR TITLE
rollback the transaction when an exception occurs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,9 +242,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
 		<version>2.16</version>	
                 <configuration>
-                    <reuseForks>false</reuseForks>
-                    <forkCount>1</forkCount>
-                    <argLine>-Xmx1024m</argLine>
+                   <argLine>-Xmx1024m</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/neo4j/server/plugin/gremlin/GremlinPlugin.java
+++ b/src/main/java/org/neo4j/server/plugin/gremlin/GremlinPlugin.java
@@ -85,7 +85,8 @@ public class GremlinPlugin extends ServerPlugin
             return representation;
         } catch ( final Exception e )
         {
-            throw new BadInputException( e.getMessage() );
+            neo4jGraph.rollback();
+	    throw new BadInputException( e.getMessage() );
         }
     }
 


### PR DESCRIPTION
This avoids the "The transaction is marked for rollback only." messages when neo4j tries to reuse the same transaction. 
