### PR TITLE
Undo groovy update for 1.9.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
         <blueprints.version>1.2</blueprints.version>
         <gremlin.version>1.5</gremlin.version>
         <jersey.server.version>1.6</jersey.server.version>
-        <groovy.version>1.8.9</groovy.version>
         <license-text.header>GPL-3-header.txt</license-text.header>
         <docs.url>http://docs.neo4j.org/chunked/${project.version}/gremlin-plugin.html</docs.url>
     </properties>
@@ -230,15 +229,6 @@
             </exclusions>
         </dependency>
 
-        <!-- force a newer version of groovy
-            artifact gremlin-groovy bundles groovy 1.8.4 which suffers from
-            http://jira.codehaus.org/browse/GROOVY-5187 -->
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy</artifactId>
-            <version>${groovy.version}</version>
-        </dependency>
-            
     </dependencies>
     <build>
         <resources>


### PR DESCRIPTION
due to permgen issues the dependency to groovy 1.8.9 needs to be removed.
